### PR TITLE
Fix #250 by making entityViewer lazy

### DIFF
--- a/Scellecs.Morpeh/Unity/Providers/EntityProvider.cs
+++ b/Scellecs.Morpeh/Unity/Providers/EntityProvider.cs
@@ -149,10 +149,10 @@ namespace Scellecs.Morpeh.Providers {
             get {
                 if (this.entityViewer == null) {
                     this.entityViewer = new Editor.EntityViewer();
+
+                    this.entityViewer.world  = World.Default;
+                    this.entityViewer.entity = this.Entity;
                 }
-                
-                this.entityViewer.world  = World.Default;
-                this.entityViewer.entity = this.Entity;
                 
                 return this.entityViewer;
             }

--- a/Scellecs.Morpeh/Unity/Providers/EntityProvider.cs
+++ b/Scellecs.Morpeh/Unity/Providers/EntityProvider.cs
@@ -80,8 +80,10 @@ namespace Scellecs.Morpeh.Providers {
             this.Initialize();
             
 #if UNITY_EDITOR
-            this.entityViewer.world = World.Default;
-            this.entityViewer.entity = this.Entity;
+            if (this.entityViewer != null) {
+                this.entityViewer.world = World.Default;
+                this.entityViewer.entity = this.Entity;
+            }
 #endif
         }
 
@@ -105,8 +107,10 @@ namespace Scellecs.Morpeh.Providers {
             }
             
 #if UNITY_EDITOR
-            this.entityViewer.world = default;
-            this.entityViewer.entity = default;
+            if (this.entityViewer != null) {
+                this.entityViewer.world = default;
+                this.entityViewer.entity = default;
+            }
 #endif
         }
 
@@ -131,15 +135,28 @@ namespace Scellecs.Morpeh.Providers {
                 return type != typeof(EntityProvider);
             }
         }
-
-        [HideIf("$" + nameof(IsNotEntityProvider))]
+        
+        private Editor.EntityViewer entityViewer;
+        
+        [HideIf("$IsNotEntityProvider")]
         [PropertyOrder(100)]
         [ShowInInspector]
         [InlineProperty]
         [HideReferenceObjectPicker]
         [HideLabel]
         [Title("","Debug Info", HorizontalLine = true)]
-        private Editor.EntityViewer entityViewer = new Editor.EntityViewer();
+        private Editor.EntityViewer EntityViewer {
+            get {
+                if (this.entityViewer == null) {
+                    this.entityViewer = new Editor.EntityViewer();
+                }
+                
+                this.entityViewer.world  = World.Default;
+                this.entityViewer.entity = this.Entity;
+                
+                return this.entityViewer;
+            }
+        }
 #endif
 #pragma warning restore 0618
     }


### PR DESCRIPTION
Fixes #250 by making entityViewer lazy using a property and extra null checks (that are only present in the Editor anyway). Drastically reduces Editor allocations count, making Mac Editor in PlayMode snappier.